### PR TITLE
test: issues API integration tests + README backend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ A fullstack issue tracking app built with FastAPI and React, created for learnin
 
 ## Stack
 
-**Backend (`be-ist`)**
+**Backend (`backend`)**
 - Python + FastAPI
-- JSON file-based storage
-- Pydantic for schema validation
+- SQLModel + SQLAlchemy (database URL from environment)
+- Alembic for migrations
+- Pydantic Settings for configuration
 
 **Frontend (`fe-ist`)**
 - React 19 + TypeScript
@@ -20,15 +21,24 @@ A fullstack issue tracking app built with FastAPI and React, created for learnin
 
 ```
 issue-tracker/
-├── be-ist/          # FastAPI backend
+├── backend/                    # FastAPI backend
+│   ├── alembic/                # DB migrations (env, versions, …)
 │   ├── app/
-│   │   ├── middleware/
-│   │   ├── routes/
-│   │   ├── schemas.py
-│   │   └── storage.py
-│   └── main.py
-└── fe-ist/          # React frontend
+│   │   ├── models/             # SQLModel models (e.g. issues)
+│   │   ├── routes/             # API routers (e.g. issues)
+│   │   ├── config.py           # Settings (env, CORS, database URL)
+│   │   ├── database.py         # Engine + session dependency
+│   │   └── main.py             # FastAPI app, CORS, exception handlers
+│   ├── tests/                  # pytest (API tests, fixtures)
+│   ├── alembic.ini
+│   ├── pyproject.toml
+│   └── uv.lock
+└── fe-ist/                     # React frontend
     ├── src/
+    │   ├── components/
+    │   ├── lib/
+    │   ├── App.tsx
+    │   └── main.tsx
     └── ...
 ```
 
@@ -36,12 +46,14 @@ issue-tracker/
 
 ### Backend
 
+Python dependencies are installed with **[uv](https://docs.astral.sh/uv/)** (not `pip`). Install [uv](https://docs.astral.sh/uv/getting-started/installation/) if you do not have it, then:
+
 ```bash
-cd be-ist
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-python main.py
+cd backend
+uv sync
+# Set DATABASE_URL in `.env` (see `app/config.py`), then apply migrations and run:
+uv run alembic upgrade head
+uv run uvicorn app.main:app --reload --port 8000
 ```
 
 API runs at `http://localhost:8000`

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,13 +1,11 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env")
     app_name: str = "Issue Tracker API"
     allowed_origins: list[str] = ['http://localhost:3000']
     database_url: str
-
-    class Config:
-        env_file = ".env"
 
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,4 +32,5 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 async def generic_exception_handler(request: Request, exc: Exception):
     return JSONResponse(status_code=500, content={'detail': "Internal server error"})
 
+
 app.include_router(issues_router)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,9 @@ requires-python = ">=3.13"
 dependencies = [
     "alembic>=1.18.4",
     "fastapi[standard]>=0.135.3",
+    "httpx>=0.28.1",
     "psycopg2-binary>=2.9.11",
+    "pytest>=9.0.3",
     "sqlmodel>=0.0.38",
 ]
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,38 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlmodel.pool import StaticPool
+
+from app.main import app
+from app.database import get_session
+
+
+@pytest.fixture(scope="function")
+def test_engine():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    SQLModel.metadata.drop_all(engine)
+
+
+@pytest.fixture()
+def db_session(test_engine):
+    with Session(test_engine) as session:
+        yield session
+
+
+@pytest.fixture()
+def client(db_session):
+    def override_get_session():
+        yield db_session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()

--- a/backend/tests/test_issues.py
+++ b/backend/tests/test_issues.py
@@ -1,0 +1,111 @@
+
+# Each test function receives `client` as a parameter.
+# pytest sees it matches the fixture name in conftest.py and injects it automatically.
+# `client` already has the test DB wired in — you don't have to do anything extra.
+
+
+def make_issue(client, **overrides):
+    payload = {
+        "title": "Test issue",
+        "description": "This is a test description",
+        "priority": "high",
+        "status": "open",
+        **overrides
+    }
+    response = client.post("/api/v1/issues", json=payload)
+
+    return response.json()
+
+
+def test_create_issue(client):
+    response = client.post("/api/v1/issues", json={
+        "title": "Test issue",
+        "description": "This is a test description",
+        "priority": "high",
+        "status": "open",
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Test issue"
+    assert data["priority"] == "high"
+    assert "id" in data  # DB assigned an id
+
+
+def test_get_issues_empty(client):
+    response = client.get("/api/v1/issues")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_get_issues(client):
+    issue = make_issue(client)
+    response = client.get('/api/v1/issues')
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    data = response.json()[0]
+    assert data['id'] == issue['id']
+    assert data['title'] == issue['title']
+    assert data['description'] == issue['description']
+    assert data['priority'] == issue['priority']
+    assert data['status'] == issue['status']
+
+
+def test_get_issue(client):
+    issue = make_issue(client)
+    response = client.get(f"/api/v1/issues/{issue['id']}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data['id'] == issue['id']
+    assert data['title'] == issue['title']
+    assert data['description'] == issue['description']
+    assert data['priority'] == issue['priority']
+    assert data['status'] == issue['status']
+
+
+def test_update_issue(client):
+    issue = make_issue(client)
+    response = client.patch(f"/api/v1/issues/{issue['id']}", json={
+        "title": "Updated title",
+        "description": "Updated description",
+        "priority": "medium",
+        "status": "in_progress",
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data['id'] == issue['id']
+    assert data['title'] == "Updated title"
+    assert data['description'] == "Updated description"
+    assert data['priority'] == "medium"
+    assert data['status'] == "in_progress"
+
+
+def test_delete_issue(client):
+    issue = make_issue(client)
+    response = client.delete(f"/api/v1/issues/{issue['id']}")
+    assert response.status_code == 200
+    response = client.get(f"/api/v1/issues/{issue['id']}")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Issue not found"}
+
+
+def test_get_issue_not_found(client):
+    response = client.get("/api/v1/issues/999999")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Issue not found"}
+
+
+def test_update_issue_not_found(client):
+    response = client.patch("/api/v1/issues/999999", json={
+        "title": "Updated title",
+        "description": "Updated description",
+        "priority": "medium",
+        "status": "in_progress",
+    })
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Issue not found"}
+
+
+def test_delete_issue_not_found(client):
+    response = client.delete("/api/v1/issues/999999")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Issue not found"}

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -57,7 +57,9 @@ source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "httpx" },
     { name = "psycopg2-binary" },
+    { name = "pytest" },
     { name = "sqlmodel" },
 ]
 
@@ -65,7 +67,9 @@ dependencies = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "sqlmodel", specifier = ">=0.0.38" },
 ]
 
@@ -344,6 +348,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -438,6 +451,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -580,6 +611,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds automated coverage for the issues REST API and updates the root README so it matches the current backend layout and tooling.

- **Tests:** Pytest integration tests for the issues endpoints using `httpx` and shared fixtures in `backend/tests/conftest.py` (`backend/tests/test_issues.py`).
- **Dependencies:** `pytest` and `httpx` added in `backend/pyproject.toml` with lockfile updates.
- **Config:** Settings use `SettingsConfigDict` so `.env` loading follows Pydantic v2 conventions (`backend/app/config.py`).
- **Docs:** README updates for the `backend/` tree (Alembic, SQLModel, tests), and Getting Started instructions that use **uv** instead of pip.

## Testing

- [ ] `cd backend && uv run pytest`